### PR TITLE
browser now: Replace Date.now() with lightstep's implementation

### DIFF
--- a/build/platform/browser/now.js
+++ b/build/platform/browser/now.js
@@ -1,8 +1,24 @@
 'use strict';
 
-var loadNs = performance.now();
-var loadMs = Date.now();
+module.exports = nowMilli();
 
-module.exports = function () {
-  return Date.now();
-};
+// The following snippet is mostly copied from the lightstep-tracer-javascript repo. One difference for our
+// implementation is that we measure our performance in milliseconds rather than microseconds.
+// We are currently evaluating lightstep and want to be consistent with how we are gathering our duration metrics.
+// source: https://github.com/lightstep/lightstep-tracer-javascript/blob/c642dd59b4ed13e8832c27345b382f5dbd2a35eb/src/imp/platform/browser/platform_browser.js#L8
+let nowMilli = (function () {
+  // Is a hi-res timer available?
+  if (window.performance &&
+      window.performance.now &&
+      window.performance.timing &&
+      window.performance.timing.navigationStart) {
+      let start = performance.timing.navigationStart;
+      return function () {
+          return Math.floor((start + performance.now()));
+      };
+  }
+  // The low-res timer is the best we can do
+  return function () {
+      return Date.now();
+  };
+}());


### PR DESCRIPTION
This commit replaces our forked dd-trace-js's browser performance
calculation from using Date.now() to using lightstep's implementation.

One key thing to note is that this will report now in milliseconds
instead of microseconds. This is consistent with our how we report our
metrics (in ms) and should fix the duration reporting inconsistencies
that we have been experiencing in recently. Specifically, we have gotten
reports of negative durations and traces that seem to start in the
future.

The main reason we suspect this "Only use Date.now()" change is that
Date.now() is used for get time relative to Unix epoch time whereas
performance.now() gets the time relative to a page load. We should use
the same method of calculating browser performance across our tools so
that we are consistent.

Going forward, we should standardize our tracing tools to using
performance.now() and defaulting to Date.now() if performance is not
available.