### PR TITLE
package.json: Upgrade to opentracing 0.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "koalas": "^1.0.2",
     "methods": "^1.1.2",
     "msgpack-lite": "^0.1.26",
-    "opentracing": "0.14.1",
+    "opentracing": "0.14.7",
     "performance-now": "^2.1.0",
     "require-dir": "^1.0.0",
     "require-in-the-middle": "^2.2.1",


### PR DESCRIPTION
This change updates from opentracing 0.14.1 to opentracing 0.14.7, the latest version, which was released on 2022-01-05. [[version history](https://www.npmjs.com/package/opentracing?activeTab=versions)]

The motivation for this is that I need to update the project that consumes samsarahq/dd-trace-js#samsara/prod-2025 to also consume the current version of dd-trace-js from Datadog, and it turns out to not be possible to do that if they consume different versions of opentracing. (The crux is that opentracing uses protected fields in certain classes &mdash; that's a TypeScript feature that means that only the class and its subclasses can access the field &mdash; so each version's copy of the class is not compatible with the other.)

Note that this is *not* a backward-compatible change. To release it safely, I've created a new not-already-used branch to merge it into, so that the consuming project can switch to the new branch simultaneously with making the requisite changes.