### PR TITLE
Msgpack package migration

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,7 +5,7 @@ require,continuation-local-storage,BSD-2-Clause,Copyright 2013-2016 Forrest L No
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
-require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
+require,@msgpack/msgpack,ISC,Copyright 2019 The MessagePack Community
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,require-dir,MIT,Copyright 2012-2015 Aseem Kishore

--- a/build/encode.js
+++ b/build/encode.js
@@ -1,8 +1,49 @@
 'use strict';
 
-var msgpack = require('msgpack-lite');
-var codec = msgpack.createCodec({ int64: true });
+var msgpack = require('@msgpack/msgpack');
+var Buffer = require('safe-buffer').Buffer;
+var Int64Buffer = require('int64-buffer');
+
+var int64Constructors = [Int64Buffer.Int64BE, Int64Buffer.Int64LE, Int64Buffer.Uint64BE, Int64Buffer.Uint64LE];
+
+function toBigInt(value) {
+  if (typeof global.BigInt !== 'function') {
+    throw new Error('BigInt support is required to encode 64-bit values');
+  }
+
+  return global.BigInt(value.toString());
+}
+
+function normalize(value) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  for (var i = 0; i < int64Constructors.length; i++) {
+    if (value instanceof int64Constructors[i]) {
+      return toBigInt(value);
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalize);
+  }
+
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return value;
+  }
+
+  var normalized = {};
+  var keys = Object.keys(value);
+
+  for (var _i = 0; _i < keys.length; _i++) {
+    var key = keys[_i];
+    normalized[key] = normalize(value[key]);
+  }
+
+  return normalized;
+}
 
 module.exports = function (data) {
-  return msgpack.encode(data, { codec: codec });
+  return Buffer.from(msgpack.encode(normalize(data), { useBigInt64: true }));
 };

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "node": ">=4"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^3.1.3",
     "cls-bluebird": "^2.1.0",
     "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.2.1",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
     "methods": "^1.1.2",
-    "msgpack-lite": "^0.1.26",
     "opentracing": "0.14.7",
     "performance-now": "^2.1.0",
     "require-dir": "^1.0.0",

--- a/src/encode.js
+++ b/src/encode.js
@@ -1,6 +1,50 @@
 'use strict'
 
-const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
+const msgpack = require('@msgpack/msgpack')
+const Buffer = require('safe-buffer').Buffer
+const Int64Buffer = require('int64-buffer')
 
-module.exports = data => msgpack.encode(data, { codec })
+const int64Constructors = [
+  Int64Buffer.Int64BE,
+  Int64Buffer.Int64LE,
+  Int64Buffer.Uint64BE,
+  Int64Buffer.Uint64LE
+]
+
+function toBigInt (value) {
+  if (typeof global.BigInt !== 'function') {
+    throw new Error('BigInt support is required to encode 64-bit values')
+  }
+
+  return global.BigInt(value.toString())
+}
+
+function normalize (value) {
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  for (const Constructor of int64Constructors) {
+    if (value instanceof Constructor) {
+      return toBigInt(value)
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalize)
+  }
+
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return value
+  }
+
+  const normalized = {}
+
+  for (const key of Object.keys(value)) {
+    normalized[key] = normalize(value[key])
+  }
+
+  return normalized
+}
+
+module.exports = data => Buffer.from(msgpack.encode(normalize(data), { useBigInt64: true }))

--- a/test/dd-trace.spec.js
+++ b/test/dd-trace.spec.js
@@ -3,9 +3,7 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const getPort = require('get-port')
-const Uint64BE = require('int64-buffer').Uint64BE
-const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
+const msgpack = require('@msgpack/msgpack')
 
 describe('dd-trace', () => {
   let tracer
@@ -41,17 +39,17 @@ describe('dd-trace', () => {
 
     agent.use(bodyParser.raw({ type: 'application/msgpack' }))
     agent.put('/v0.3/traces', (req, res) => {
-      const payload = msgpack.decode(req.body, { codec })
+      const payload = msgpack.decode(req.body, { useBigInt64: true })
 
-      expect(payload[0][0].trace_id).to.be.instanceof(Uint64BE)
+      expect(typeof payload[0][0].trace_id).to.equal('bigint')
       expect(payload[0][0].trace_id.toString()).to.equal(span.context().traceId.toString())
-      expect(payload[0][0].span_id).to.be.instanceof(Uint64BE)
+      expect(typeof payload[0][0].span_id).to.equal('bigint')
       expect(payload[0][0].span_id.toString()).to.equal(span.context().spanId.toString())
       expect(payload[0][0].service).to.equal('test')
       expect(payload[0][0].name).to.equal('hello')
       expect(payload[0][0].resource).to.equal('/hello/:name')
-      expect(payload[0][0].start).to.be.instanceof(Uint64BE)
-      expect(payload[0][0].duration).to.be.instanceof(Uint64BE)
+      expect(typeof payload[0][0].start).to.equal('bigint')
+      expect(typeof payload[0][0].duration).to.equal('bigint')
 
       res.status(200).send('OK')
 

--- a/test/encode.spec.js
+++ b/test/encode.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
+const msgpack = require('@msgpack/msgpack')
 const Uint64BE = require('int64-buffer').Uint64BE
 
 describe('encode', () => {
@@ -18,10 +17,11 @@ describe('encode', () => {
     }]
 
     const buffer = encode(data)
-    const decoded = msgpack.decode(buffer, { codec })
+    const decoded = msgpack.decode(buffer, { useBigInt64: true })
 
     expect(decoded).to.be.instanceof(Array)
     expect(decoded[0]).to.be.instanceof(Object)
+    expect(typeof decoded[0].id).to.equal('bigint')
     expect(decoded[0].id.toString()).to.equal(data[0].id.toString())
     expect(decoded[0].name).to.equal(data[0].name)
   })

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -2,8 +2,7 @@
 
 const http = require('http')
 const bodyParser = require('body-parser')
-const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
+const msgpack = require('@msgpack/msgpack')
 const getPort = require('get-port')
 const express = require('express')
 
@@ -17,7 +16,7 @@ module.exports = {
     agent = express()
     agent.use(bodyParser.raw({ type: 'application/msgpack' }))
     agent.use((req, res, next) => {
-      req.body = msgpack.decode(req.body, { codec })
+      req.body = msgpack.decode(req.body, { useBigInt64: true })
       next()
     })
 


### PR DESCRIPTION
Replace `msgpack-lite` with `@msgpack/msgpack` to use a more modern and maintained MessagePack library.

The migration involved updating API calls and ensuring compatibility for 64-bit integers by converting `int64-buffer` objects to `BigInt` during encoding and decoding.

---
<p><a href="https://cursor.com/agents/bc-c18b9537-63a4-47fa-b6eb-4f5fcc727bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18b9537-63a4-47fa-b6eb-4f5fcc727bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

